### PR TITLE
Latest msys2 (msys2-x86_64-20180531.exe at time of commit) uses msys2_shell.cmd instead of .bat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 # CMD shell integration for MSYS2
 
+To install, either this script must be located in a cmd\ sub-directory of the MSYS2 installation, or the root directory of the MSYS2 installation (usually C:\path\to\msys32 or ...\msys64) must be defined via %%MSYS2_ROOT%% or must be in %%PATH%%.
+
 Licensed under the [Apache License, Version 2.0](
   http://www.apache.org/licenses/LICENSE-2.0)

--- a/msystem.bat
+++ b/msystem.bat
@@ -128,7 +128,7 @@ if not "%MSYS2_ROOT%" == "" (
 )
 
 REM try to find MSYS2 root directory in %PATH%
-for %%S in (msys2_shell.bat) do (
+for %%S in (msys2_shell.cmd) do (
     set "MSYS2_ROOT=%%~dp$PATH:S"
     if not "!MSYS2_ROOT!" == "" (
         goto :checkRoot
@@ -147,7 +147,7 @@ for %%D in ("%cmdRoot:~0,-1%") do (
 
 REM remove trailing \
 set "MSYS2_ROOT=%MSYS2_ROOT:~0,-1%"
-if not exist "%MSYS2_ROOT%\msys2_shell.bat" (
+if not exist "%MSYS2_ROOT%\msys2_shell.cmd" (
     echo This script is not properly installed.
     echo Should be in ^<MSYS2 root^>\cmd\
     exit /b 1


### PR DESCRIPTION
Also updated readme with basic installation instructions.